### PR TITLE
Add My Trophies section with Credly, PSN, and Steam links

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -204,3 +204,40 @@ section.main ul li a:hover {
         opacity: 1
     }
 }
+
+/* Trophies Section */
+
+.trophies-section {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 8px;
+}
+
+.trophies-links {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    gap: 8px;
+}
+
+.trophy-link {
+    outline: none;
+    text-decoration: none;
+    color: #a6a8b8;
+    padding: 0;
+    transition: 0.3s all;
+    font-size: 14px;
+    display: flex;
+    align-items: center;
+    white-space: nowrap;
+}
+
+.trophy-link:hover {
+    color: white;
+}
+
+.trophy-separator {
+    color: #a6a8b8;
+    margin: 0 4px;
+}

--- a/index.html
+++ b/index.html
@@ -26,10 +26,25 @@
             <div class="header_links">
                 <ul class="nav_links" style="float: right; list-style-type: none; margin: 0; padding: 0;">
                     <li class="nav_link">
-                        <a href="https://western-aletopelta-c3c.notion.site/Published-Jin-s-Free-Note-7dcafdd576e146c2bbff9d948e4217f4" target="_blank" class="blog-link">
-                            <img src="assets/imgs/cat-shaking.gif" alt="Notion Blog" style="width: 35px; height: 35px; vertical-align: middle;">
-                            <span style="margin-left: 8px;">Visit my blog</span>
-                        </a>
+                        <div class="trophies-section">
+                            <h3 style="margin: 0; font-size: 16px;">
+                                <img src="assets/imgs/cat-shaking.gif" alt="My Trophies" style="width: 20px; height: 20px; vertical-align: middle; margin-right: 6px;">
+                                My Trophies
+                            </h3>
+                            <div class="trophies-links">
+                                <a href="https://www.credly.com/users/jin-huang.15f65657" target="_blank" class="trophy-link">
+                                    <span style="font-size: 14px;">🏆 Credly</span>
+                                </a>
+                                <span class="trophy-separator">/</span>
+                                <a href="https://psnprofiles.com/jin1206t" target="_blank" class="trophy-link">
+                                    <span style="font-size: 14px;">🏆 PSN</span>
+                                </a>
+                                <span class="trophy-separator">/</span>
+                                <a href="https://steamcommunity.com/profiles/76561199071846196/" target="_blank" class="trophy-link">
+                                    <span style="font-size: 14px;">🏆 Steam</span>
+                                </a>
+                            </div>
+                        </div>
                     </li>
                 </ul>
             </div>


### PR DESCRIPTION
- Replace Visit my blog link with My Trophies section
- Display trophies horizontally with trophy icons ()
- Add Credly professional badges link
- Add PSN trophies link
- Add Steam achievements link
- Use cat-shaking.gif icon for section header
- Shortened labels to Credly, PSN, and Steam